### PR TITLE
Enable dnf module only on RHEL 8

### DIFF
--- a/02_satellite_installer.yml
+++ b/02_satellite_installer.yml
@@ -66,6 +66,7 @@
         - name: 'Enable the satellite dnf module'
           ansible.builtin.shell:
             cmd: 'dnf module enable satellite:el8 -y'
+          when: (ansible_distribution == "RedHat" and ansible_distribution_major_version == "8")
           changed_when: true
 
         - name: 'Update all packages'

--- a/02_satellite_installer.yml
+++ b/02_satellite_installer.yml
@@ -66,7 +66,9 @@
         - name: 'Enable the satellite dnf module'
           ansible.builtin.shell:
             cmd: 'dnf module enable satellite:el8 -y'
-          when: (ansible_distribution == "RedHat" and ansible_distribution_major_version == "8")
+          when:
+            - "ansible_distribution == 'RedHat'"
+            - "ansible_distribution_major_version | int == 8'
           changed_when: true
 
         - name: 'Update all packages'


### PR DESCRIPTION
This change avoids an error on RHEL 9 where dnf modules no longer apply.